### PR TITLE
Configure Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,23 @@ jobs:
       script:
       - eslint . --max-warnings=0
 
-  # include:
-  #   - stage: test backend
-  #     <<: *x-backend
-  #     script:
-  #     - npm run test
+  include:
+    - stage: test backend
+      before_install:
+      - cd backend
+      script:
+      - npm run test
+
+  include:
+    - stage: lint frontend
+      before_install:
+      - cd frontend
+      script:
+      - eslint . --max-warnings=0
+
+  include:
+    - stage: test frontend
+      before_install:
+      - cd frontend
+      script:
+      - npm run test -- --watchAll=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,29 +2,17 @@
 git:
   depth: 1
 
-# Custom configuration key, that can be referenced
-# by *name, and imported by <<: *name.
-x-backend: &x-backend
-  language: node_js
-  node_js:
-    - "node" # latest version
-  before_install: cd backend
-
-x-frontend: &x-frontend
-  language: node_js
-  node_js:
-    - "node" # latest version
-  before_install: cd frontend
+os: linux
+dist: bionic
+language: node_js
+node_js: node
 
 # Based on https://github.com/nokia-wroclaw/innovativeproject-sudoku/blob/3402e16849db852167e6eadce6c952e889e2c1d2/.travis.yml
-matrix:
-  stages:
-    - lint
-    - test
-
+jobs:
   include:
     - stage: lint backend
-      <<: *x-backend
+      before_install:
+      - cd backend
       script:
       - eslint . --max-warnings=0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,26 +10,16 @@ node_js: node
 # Based on https://github.com/nokia-wroclaw/innovativeproject-sudoku/blob/3402e16849db852167e6eadce6c952e889e2c1d2/.travis.yml
 jobs:
   include:
-  - stage: lint backend
+  - stage: test and lint backend
     before_install:
     - cd backend
     script:
     - eslint . --max-warnings=0
-
-  - stage: test backend
-    before_install:
-    - cd backend
-    script:
     - npm run test
 
-  - stage: lint frontend
+  - stage: test and lint frontend
     before_install:
     - cd frontend
     script:
     - eslint . --max-warnings=0
-
-  - stage: test frontend
-    before_install:
-    - cd frontend
-    script:
     - npm run test -- --watchAll=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,29 +10,26 @@ node_js: node
 # Based on https://github.com/nokia-wroclaw/innovativeproject-sudoku/blob/3402e16849db852167e6eadce6c952e889e2c1d2/.travis.yml
 jobs:
   include:
-    - stage: lint backend
-      before_install:
-      - cd backend
-      script:
-      - eslint . --max-warnings=0
+  - stage: lint backend
+    before_install:
+    - cd backend
+    script:
+    - eslint . --max-warnings=0
 
-  include:
-    - stage: test backend
-      before_install:
-      - cd backend
-      script:
-      - npm run test
+  - stage: test backend
+    before_install:
+    - cd backend
+    script:
+    - npm run test
 
-  include:
-    - stage: lint frontend
-      before_install:
-      - cd frontend
-      script:
-      - eslint . --max-warnings=0
+  - stage: lint frontend
+    before_install:
+    - cd frontend
+    script:
+    - eslint . --max-warnings=0
 
-  include:
-    - stage: test frontend
-      before_install:
-      - cd frontend
-      script:
-      - npm run test -- --watchAll=false
+  - stage: test frontend
+    before_install:
+    - cd frontend
+    script:
+    - npm run test -- --watchAll=false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+# Only fetch the current version, without history.
+git:
+  depth: 1
+
+# Custom configuration key, that can be referenced
+# by *name, and imported by <<: *name.
+x-backend: &x-backend
+  language: node_js
+  node_js:
+    - "node" # latest version
+  before_install: cd backend
+
+x-frontend: &x-frontend
+  language: node_js
+  node_js:
+    - "node" # latest version
+  before_install: cd frontend
+
+# Based on https://github.com/nokia-wroclaw/innovativeproject-sudoku/blob/3402e16849db852167e6eadce6c952e889e2c1d2/.travis.yml
+matrix:
+  stages:
+    - lint
+    - test
+
+  include:
+    - stage: lint backend
+      <<: *x-backend
+      script:
+      - eslint . --max-warnings=0
+
+  # include:
+  #   - stage: test backend
+  #     <<: *x-backend
+  #     script:
+  #     - npm run test


### PR DESCRIPTION
See #5 

So far it runs lints and tests.

When using 4 stages, running it on my fork took 5 minutes to complete (including 2,5m of VMs running). In order to decrease CI times, I merged 4 stages into 2 stages, so that we won't need to wait for new VMs for so long. This way, the wait time decreased to 2 minutes 20 seconds. It would be nice to be able to merge it into a single stage, but Travis runs `npm ci` (equivalent to `npm install` in effect) automatically once for each stage, while we need to run it twice. So, I'm okay with the current version (2 stages).