### PR TITLE
Increase Travis clone depth

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
-# Only fetch the current version, without history.
+# We want to only fetch the current version, without history.
+# But we will fetch few more commits in case of rapid changes
+# (new commit pushed in the middle of previous CI run).
 git:
-  depth: 1
+  depth: 5
 
 os: linux
 dist: bionic


### PR DESCRIPTION
My bad: If you `git push` before Travis runs `git clone --depth 1 ... && git checkout ...`, the checkout will fail (as the downloaded commit will have a different hash).