### PR TITLE
Add startDate paramater to backend

### DIFF
--- a/backend/app/calendar-client.js
+++ b/backend/app/calendar-client.js
@@ -22,11 +22,12 @@ class CalendarClient {
       return res.data;
    }
 
-   async getEvents( calendarId ) {
+   async getEvents( calendarId, startDate ) {
       const res = await this.connection.events.list( {
          calendarId,
-         timeMin: ( new Date() ).toISOString(),
-         maxResults: 10,
+         timeMin: startDate.format(),
+         timeMax: startDate.add( 1, 'week' ).format(),
+         maxResults: 100,
          singleEvents: true,
          orderBy: 'startTime',
       } );

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -6021,6 +6021,11 @@
         "minimist": "0.0.8"
       }
     },
+    "moment": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
+      "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+    },
     "morgan": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/morgan/-/morgan-1.9.1.tgz",

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,6 +15,7 @@
       "dotenv": "^8.2.0",
       "express": "~4.16.1",
       "googleapis": "^48.0.0",
+      "moment": "^2.24.0",
       "morgan": "~1.9.1"
    },
    "devDependencies": {

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -1,4 +1,5 @@
 const express = require( 'express' );
+const moment = require( 'moment' );
 const { CalendarClient } = require( '../app/calendar-client' );
 
 const router = express.Router();
@@ -24,9 +25,12 @@ router.get( '/calendar/:calendar', async ( req, res ) => {
    try {
       const calendarUri = `${req.params.calendar}@group.calendar.google.com`;
 
+      if ( typeof req.query.startDate === 'undefined' ) throw new Error( 'startDate is required' );
+      const startDate = moment( req.query.startDate );
+
       const client = new CalendarClient();
       const calendar = await client.getCalendar( calendarUri );
-      const events = await client.getEvents( calendar.id );
+      const events = await client.getEvents( calendar.id, startDate );
       res.send( { calendar, events } );
    }
    catch ( e ) {

--- a/backend/routes/index.test.js
+++ b/backend/routes/index.test.js
@@ -27,8 +27,11 @@ it( 'Provides /api/calendars endpoint', async () => {
 } );
 
 it( 'Returns calendar via /api/calendar/*', async () => {
-   const res = await request.get( '/api/calendar/test' );
+   const res = await request.get( '/api/calendar/test?startDate=2020-01-01' );
    expect( res.statusCode ).toBe( 200 );
+
+   const res2 = await request.get( '/api/calendar/test' );
+   expect( res2.statusCode ).toBe( 400 );
 
    expect( res.body.calendar ).toBeDefined();
    expect( typeof res.body.calendar.id ).toBe( 'string' );
@@ -42,6 +45,12 @@ it( 'Returns error via /api/calendar/* when calendar does not exist', async () =
    const res1 = await request.get( '/api/calendar/test2' );
    expect( res1.statusCode ).toBe( 400 );
 
-   const res2 = await request.get( '/api/calendar/tes' );
+   const res2 = await request.get( '/api/calendar/test2?startDate=2020-01-01' );
    expect( res2.statusCode ).toBe( 400 );
+
+   const res3 = await request.get( '/api/calendar/tes' );
+   expect( res3.statusCode ).toBe( 400 );
+
+   const res4 = await request.get( '/api/calendar/tes?startDate=2020-01-01' );
+   expect( res4.statusCode ).toBe( 400 );
 } );


### PR DESCRIPTION
The `/api/calendar/:calendar` endpoint will now return events for a week starting from the given date. The date can be in many formats due to the usage of moment.js, though `toISOString()` format is preferred (probably only one supported in the future).