### PR TITLE
Add memoization for API queries

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -6,12 +6,16 @@ import Index from './pages/index/Index';
 import Calendars from './pages/Calendars/Calendars';
 import Room from './pages/Room/Room';
 import PageTemplate from './templates/PageTemplate/PageTemplate';
-
+import Fetcher from './services/fetching/Fetcher';
+import FetchContext from './services/fetching/FetchContext';
 
 const App = () => {
+   const fetcher = new Fetcher();
+   const fetchAPI = fetcher.bindFetchAPI();
+
    return (
-      <Router>
-         <>
+      <FetchContext.Provider value={ fetchAPI }>
+         <Router>
             <PageTemplate>
                <Switch>
                   <Route path="/calendars" >
@@ -25,8 +29,8 @@ const App = () => {
                   </Route>
                </Switch>
             </PageTemplate>
-         </>
-      </Router>
+         </Router>
+      </FetchContext.Provider>
    );
 };
 

--- a/frontend/src/pages/Calendars/Calendars.js
+++ b/frontend/src/pages/Calendars/Calendars.js
@@ -1,35 +1,24 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import CalendarList from '../../components/CalendarList/CalendarList';
-import { constants } from '../../assets/configs/constants';
+import FetchContext from '../../services/fetching/FetchContext';
 
 const Calendars = () => {
    const [ calendars, setCalendars ] = useState( [] );
    const [ isLoading, setIsLoading ] = useState( true );
+   const fetchAPI = useContext( FetchContext );
+
    useEffect( () => {
-      const controller = new AbortController();
-      const { signal } = controller;
+      const [ promise, abort ] = fetchAPI( 'calendars' );
+      promise.then( ( data ) => {
+         const calendarList = data.filter(
+            ( calendar ) => calendar.summary.slice( 0, 5 ) === 'ROOM_'
+         );
+         setCalendars( calendarList );
+         setIsLoading( false );
+      } );
 
-      fetch(
-         `${
-            constants.url.API_URL
-         }calendars`,
-         { signal }
-      )
-         .then( ( response ) => response.json() )
-         .then( ( data ) => {
-            const calendarList = data.filter(
-               ( calendar ) => calendar.summary.slice( 0, 5 ) === 'ROOM_'
-            );
-            setCalendars( calendarList );
-            setIsLoading( false );
-         } )
-         // eslint-disable-next-line no-console
-         .catch( ( error ) => console.log( error ) );
-
-      return () => {
-         controller.abort();
-      };
-   }, [] );
+      return abort;
+   }, [ fetchAPI ] );
 
    return (
       <>

--- a/frontend/src/pages/Room/Room.js
+++ b/frontend/src/pages/Room/Room.js
@@ -1,42 +1,31 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useContext } from 'react';
 import moment from 'moment';
 import { useParams } from 'react-router-dom';
-import { constants } from '../../assets/configs/constants';
 import EventList from '../../components/EventList/EventList';
 import RoomData from '../../components/RoomData/RoomData';
+import FetchContext from '../../services/fetching/FetchContext';
 
 const Room = () => {
    const [ calendar, setCalendar ] = useState( [] );
    const [ isLoading, setIsLoading ] = useState( true );
    const [ startDate, setStartDate ] = useState( '' );
    const { roomId } = useParams();
+   const fetchAPI = useContext( FetchContext );
 
    useEffect( () => {
       const startDateTmp = moment().startOf( 'day' ).toISOString();
       setStartDate( startDateTmp );
-      const controller = new AbortController();
-      const { signal } = controller;
 
-      fetch(
-         `${constants.url.API_URL}calendar/${
-            roomId.split( '@' )[0]
-         }?startDate=${startDateTmp}`,
-         {
-            signal,
-         }
-      )
-         .then( ( response ) => response.json() )
-         .then( ( data ) => {
-            setCalendar( data );
-            setIsLoading( false );
-         } )
-         // eslint-disable-next-line no-console
-         .catch( ( error ) => console.log( error ) );
+      const [ promise, abort ] = fetchAPI( `calendar/${
+         roomId.split( '@' )[0]
+      }?startDate=${startDateTmp}` );
+      promise.then( ( data ) => {
+         setCalendar( data );
+         setIsLoading( false );
+      } );
 
-      return () => {
-         controller.abort();
-      };
-   }, [ roomId ] );
+      return abort;
+   }, [ roomId, fetchAPI ] );
 
    return (
       <>

--- a/frontend/src/services/fetching/FetchContext.js
+++ b/frontend/src/services/fetching/FetchContext.js
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export default React.createContext( null );

--- a/frontend/src/services/fetching/Fetcher.js
+++ b/frontend/src/services/fetching/Fetcher.js
@@ -1,0 +1,44 @@
+import { constants } from '../../assets/configs/constants';
+
+class Fetcher {
+   constructor() {
+      this.cache = new Map();
+   }
+
+   fetchAPI( urlFragment ) {
+      if ( this.cache.has( urlFragment ) ) {
+         const promise = new Promise( ( resolve ) => {
+            resolve( this.cache.get( urlFragment ) );
+         } );
+
+         const abort = () => { };
+
+         return [ promise, abort ];
+      }
+
+      const controller = new AbortController();
+      const { signal } = controller;
+      const abort = () => controller.abort();
+
+      const promise = fetch(
+         `${constants.url.API_URL}${urlFragment}`,
+         { signal }
+      )
+         .then( ( response ) => response.json() )
+         .then( ( data ) => {
+            this.cache.set( urlFragment, data );
+
+            return data;
+         } )
+         // eslint-disable-next-line no-console
+         .catch( ( error ) => console.log( error ) );
+
+      return [ promise, abort ];
+   }
+
+   bindFetchAPI() {
+      return this.fetchAPI.bind( this );
+   }
+}
+
+export default Fetcher;


### PR DESCRIPTION
This PR adds a `Fetcher` service provider, that allows us to cache query results. I also extracted some common parts of data fetching process (getting API URL, casting to JSON) into it, simplifying places where we fetch data, so that only the custom logic is left.

For now, all query results are cached indefinitely (until the application is unloaded).