### PR TITLE
Better fetching and caching

### DIFF
--- a/frontend/src/pages/Room/Room.js
+++ b/frontend/src/pages/Room/Room.js
@@ -22,7 +22,7 @@ const Room = () => {
 
       const [ promise, abort ] = fetchAPI( `calendar/${
          roomId.split( '@' )[0]
-      }?startDate=${startDateTmp}` );
+      }?startDate=${startDateTmp}`, 15 );
       promise.then( ( data ) => {
          setCalendar( data );
          setIsLoading( false );

--- a/frontend/src/services/fetching/Fetcher.js
+++ b/frontend/src/services/fetching/Fetcher.js
@@ -6,15 +6,13 @@ class Fetcher {
       // `cache` entries are in the following format:
       // "url/fragment" -> { "data": {}, "retrievedAt": moment() }
       this.cache = new Map();
-      // 5 minutes.
-      this.ttl = 5 * 60;
    }
 
-   fetchAPI( urlFragment ) {
+   fetchAPI( urlFragment, freshness = 5 * 60 ) {
       if ( this.cache.has( urlFragment ) ) {
          const entry = this.cache.get( urlFragment );
 
-         if ( moment().diff( entry.retrievedAt, 'seconds' ) < this.ttl ) {
+         if ( moment().diff( entry.retrievedAt, 'seconds' ) < freshness ) {
             const promise = ( async () => entry.data )();
 
             const abort = () => { };


### PR DESCRIPTION
Right now we are caching API responses indefinitely (#30). This PR will make calendar list to be cached for 5 minutes, and event list in a calendar for 15 seconds.

This PR also improves errors. Before errors were only logged to the console, and they did not stop execution (so concurrent errors were appearing, e.g. `data` having the wrong type). Now we will propagate errors and inform the users via `alert`.