### PR TITLE
Display room metadata

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11370,6 +11370,14 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.6.tgz",
       "integrity": "sha512-Yzpno3enVzSrSCnnljmr4b/2KUQSMZaPuqmS26t9k4nW7uwJk6STWmH9heNjPuvqUTO3jOSPkHoKgO4+Dw7uIw=="
     },
+    "react-icons": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-3.10.0.tgz",
+      "integrity": "sha512-WsQ5n1JToG9VixWilSo1bHv842Cj5aZqTGiS3Ud47myF6aK7S/IUY2+dHcBdmkQcCFRuHsJ9OMUI0kTDfjyZXQ==",
+      "requires": {
+        "camelcase": "^5.0.0"
+      }
+    },
     "react-is": {
       "version": "16.13.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.0.tgz",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9625,6 +9625,11 @@
         "word-wrap": "~1.2.3"
       }
     },
+    "ordinal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/ordinal/-/ordinal-1.0.3.tgz",
+      "integrity": "sha512-cMddMgb2QElm8G7vdaa02jhUNbTSrhsgAGUz1OokD83uJTwSUn+nKoNoKVVaRa08yF6sgfO7Maou1+bgLd9rdQ=="
+    },
     "original": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/original/-/original-1.0.2.tgz",

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -982,6 +982,16 @@
         "regenerator-runtime": "^0.13.4"
       }
     },
+    "@babel/runtime-corejs3": {
+      "version": "7.9.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.9.2.tgz",
+      "integrity": "sha512-HHxmgxbIzOfFlZ+tdeRKtaxWOMUoCG5Mu3wKeUmOxjYrwb3AAHgnmtCUbPPK11/raIWLIBK250t8E2BPO0p7jA==",
+      "dev": true,
+      "requires": {
+        "core-js-pure": "^3.0.0",
+        "regenerator-runtime": "^0.13.4"
+      }
+    },
     "@babel/template": {
       "version": "7.8.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
@@ -3498,6 +3508,12 @@
         }
       }
     },
+    "core-js-pure": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
+      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
+      "dev": true
+    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -4565,31 +4581,31 @@
       }
     },
     "eslint-config-airbnb": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.0.1.tgz",
-      "integrity": "sha512-hLb/ccvW4grVhvd6CT83bECacc+s4Z3/AEyWQdIT2KeTsG9dR7nx1gs7Iw4tDmGKozCNHFn4yZmRm3Tgy+XxyQ==",
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb/-/eslint-config-airbnb-18.1.0.tgz",
+      "integrity": "sha512-kZFuQC/MPnH7KJp6v95xsLBf63G/w7YqdPfQ0MUanxQ7zcKUNG8j+sSY860g3NwCBOa62apw16J6pRN+AOgXzw==",
       "dev": true,
       "requires": {
-        "eslint-config-airbnb-base": "^14.0.0",
+        "eslint-config-airbnb-base": "^14.1.0",
         "object.assign": "^4.1.0",
-        "object.entries": "^1.1.0"
+        "object.entries": "^1.1.1"
       }
     },
     "eslint-config-airbnb-base": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.0.0.tgz",
-      "integrity": "sha512-2IDHobw97upExLmsebhtfoD3NAKhV4H0CJWP3Uprd/uk+cHuWYOczPVxQ8PxLFUAw7o3Th1RAU8u1DoUpr+cMA==",
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.1.0.tgz",
+      "integrity": "sha512-+XCcfGyCnbzOnktDVhwsCAx+9DmrzEmuwxyHUJpw+kqBVT744OUBrB09khgFKlK1lshVww6qXGsYPZpavoNjJw==",
       "dev": true,
       "requires": {
-        "confusing-browser-globals": "^1.0.7",
+        "confusing-browser-globals": "^1.0.9",
         "object.assign": "^4.1.0",
-        "object.entries": "^1.1.0"
+        "object.entries": "^1.1.1"
       }
     },
     "eslint-config-prettier": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
-      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
+      "integrity": "sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
@@ -4628,15 +4644,28 @@
       }
     },
     "eslint-loader": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-3.0.3.tgz",
-      "integrity": "sha512-+YRqB95PnNvxNp1HEjQmvf9KNvCin5HXYYseOXVC2U0KEcw4IkQ2IQEBG46j7+gW39bMzeu0GsUhVbBY3Votpw==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-3.0.4.tgz",
+      "integrity": "sha512-I496aBd+Hi23Y0Cx+sKvw+VwlJre4ScIRlkrvTO6Scq68X/UXbN6F3lAhN8b0Zv8atAyprkyrA42K5QBJtCyaw==",
+      "dev": true,
       "requires": {
         "fs-extra": "^8.1.0",
-        "loader-fs-cache": "^1.0.2",
+        "loader-fs-cache": "^1.0.3",
         "loader-utils": "^1.2.3",
-        "object-hash": "^2.0.1",
-        "schema-utils": "^2.6.1"
+        "object-hash": "^2.0.3",
+        "schema-utils": "^2.6.5"
+      },
+      "dependencies": {
+        "schema-utils": {
+          "version": "2.6.6",
+          "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-2.6.6.tgz",
+          "integrity": "sha512-wHutF/WPSbIi9x6ctjGGk2Hvl0VOz5l3EKEuKbjPlB30mKZUzb9A5k9yEXRX3pwyqVLPvpfZZEllaFq/M718hA==",
+          "dev": true,
+          "requires": {
+            "ajv": "^6.12.0",
+            "ajv-keywords": "^3.4.1"
+          }
+        }
       }
     },
     "eslint-module-utils": {
@@ -4718,9 +4747,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.20.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.1.tgz",
-      "integrity": "sha512-qQHgFOTjguR+LnYRoToeZWT62XM55MBVXObHM6SKFd1VzDcX/vqT1kAz8ssqigh5eMj8qXcRoXXGZpPP6RfdCw==",
+      "version": "2.20.2",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.2.tgz",
+      "integrity": "sha512-FObidqpXrR8OnCh4iNsxy+WACztJLXAHBO5hK79T1Hc77PgQZkyDGA5Ag9xAvRpglvLNxhH/zSmZ70/pZ31dHg==",
       "dev": true,
       "requires": {
         "array-includes": "^3.0.3",
@@ -4888,18 +4917,18 @@
       }
     },
     "eslint-plugin-prettier": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
-      "integrity": "sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.3.tgz",
+      "integrity": "sha512-+HG5jmu/dN3ZV3T6eCD7a4BlAySdN7mLIbJYo0z1cFQuI+r2DiTJEFeF68ots93PsnrMxbzIZ2S/ieX+mkrBeQ==",
       "dev": true,
       "requires": {
         "prettier-linter-helpers": "^1.0.0"
       }
     },
     "eslint-plugin-react": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.18.3.tgz",
-      "integrity": "sha512-Bt56LNHAQCoou88s8ViKRjMB2+36XRejCQ1VoLj716KI1MoE99HpTVvIThJ0rvFmG4E4Gsq+UgToEjn+j044Bg==",
+      "version": "7.19.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.19.0.tgz",
+      "integrity": "sha512-SPT8j72CGuAP+JFbT0sJHOB80TX/pu44gQ4vXH/cq+hQTiY2PuZ6IHkqXJV6x1b28GDdo1lbInjKUrrdUf0LOQ==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.1",
@@ -4910,8 +4939,10 @@
         "object.fromentries": "^2.0.2",
         "object.values": "^1.1.1",
         "prop-types": "^15.7.2",
-        "resolve": "^1.14.2",
-        "string.prototype.matchall": "^4.0.2"
+        "resolve": "^1.15.1",
+        "semver": "^6.3.0",
+        "string.prototype.matchall": "^4.0.2",
+        "xregexp": "^4.3.0"
       },
       "dependencies": {
         "doctrine": {
@@ -4921,6 +4952,15 @@
           "dev": true,
           "requires": {
             "esutils": "^2.0.2"
+          }
+        },
+        "resolve": {
+          "version": "1.17.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+          "dev": true,
+          "requires": {
+            "path-parse": "^1.0.6"
           }
         }
       }
@@ -8024,17 +8064,17 @@
       "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
     },
     "lint-staged": {
-      "version": "10.0.8",
-      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.0.8.tgz",
-      "integrity": "sha512-Oa9eS4DJqvQMVdywXfEor6F4vP+21fPHF8LUXgBbVWUSWBddjqsvO6Bv1LwMChmgQZZqwUvgJSHlu8HFHAPZmA==",
+      "version": "10.1.7",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-10.1.7.tgz",
+      "integrity": "sha512-ZkK8t9Ep/AHuJQKV95izSa+DqotftGnSsNeEmCSqbQ6j4C4H0jDYhEZqVOGD1Q2Oe227igbqjMWycWyYbQtpoA==",
       "dev": true,
       "requires": {
-        "chalk": "^3.0.0",
-        "commander": "^4.0.1",
+        "chalk": "^4.0.0",
+        "commander": "^5.0.0",
         "cosmiconfig": "^6.0.0",
         "debug": "^4.1.1",
         "dedent": "^0.7.0",
-        "execa": "^3.4.0",
+        "execa": "^4.0.0",
         "listr": "^0.14.3",
         "log-symbols": "^3.0.0",
         "micromatch": "^4.0.2",
@@ -8064,9 +8104,9 @@
           }
         },
         "chalk": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-          "integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+          "integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
           "dev": true,
           "requires": {
             "ansi-styles": "^4.1.0",
@@ -8089,9 +8129,9 @@
           "dev": true
         },
         "commander": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
-          "integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-5.0.0.tgz",
+          "integrity": "sha512-JrDGPAKjMGSP1G0DUoaceEJ3DZgAfr/q6X7FVk4+U5KxUSKviYGM2k6zWkfyyBHy5rAtzgYJFa1ro2O9PtoxwQ==",
           "dev": true
         },
         "cosmiconfig": {
@@ -8108,9 +8148,9 @@
           }
         },
         "cross-spawn": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
-          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
+          "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
           "dev": true,
           "requires": {
             "path-key": "^3.1.0",
@@ -8119,9 +8159,9 @@
           }
         },
         "execa": {
-          "version": "3.4.0",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-3.4.0.tgz",
-          "integrity": "sha512-r9vdGQk4bmCuK1yKQu1KTwcT2zwfWdbdaXfCtAh+5nU/4fSX+JAb7vZGvI5naJrQlvONrEB20jeruESI69530g==",
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.0.0.tgz",
+          "integrity": "sha512-JbDUxwV3BoT5ZVXQrSVbAiaXhXUkIwvbhPIwZ0N13kX+5yCzOhUNdocxB/UQRuYOHRYYwAxKYwJYc0T4D12pDA==",
           "dev": true,
           "requires": {
             "cross-spawn": "^7.0.0",
@@ -8131,7 +8171,6 @@
             "merge-stream": "^2.0.0",
             "npm-run-path": "^4.0.0",
             "onetime": "^5.1.0",
-            "p-finally": "^2.0.0",
             "signal-exit": "^3.0.2",
             "strip-final-newline": "^2.0.0"
           }
@@ -8206,12 +8245,6 @@
           "requires": {
             "path-key": "^3.0.0"
           }
-        },
-        "p-finally": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-          "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-          "dev": true
         },
         "parse-json": {
           "version": "5.0.0",
@@ -9929,9 +9962,9 @@
       }
     },
     "polished": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/polished/-/polished-3.5.1.tgz",
-      "integrity": "sha512-GVbvskpBiDV5TknurGL6OyFfLHsCknxbU8w5iMppT8rW0tLEoQHrIRfrPNPqGXNj3HGhkjRvhmg59Fy7HSnCAw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/polished/-/polished-3.5.2.tgz",
+      "integrity": "sha512-vWoRDg3gY5RQBtUfcj9MRN10VCIf4EkdUikGxyXItg2Hnwk+eIVtdBiLajN0ldFeT3Vq4r/QNbjrQdhqBKrTug==",
       "requires": {
         "@babel/runtime": "^7.8.7"
       }
@@ -11145,9 +11178,9 @@
       }
     },
     "react": {
-      "version": "16.13.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.13.0.tgz",
-      "integrity": "sha512-TSavZz2iSLkq5/oiE7gnFzmURKZMltmi193rm5HEoUDAXpzT9Kzw6oNZnGoai/4+fUnm7FqS5dwgUL34TujcWQ==",
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-16.13.1.tgz",
+      "integrity": "sha512-YMZQQq32xHLX0bz5Mnibv1/LHb3Sqzngu7xstSM+vrkE5Kzr9xE0yMByK5kMoTK30YVJE61WfbxIFFvfeDKT1w==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -11355,14 +11388,14 @@
       }
     },
     "react-dom": {
-      "version": "16.13.0",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.0.tgz",
-      "integrity": "sha512-y09d2c4cG220DzdlFkPTnVvGTszVvNpC73v+AaLGLHbkpy3SSgvYq8x0rNwPJ/Rk/CicTNgk0hbHNw1gMEZAXg==",
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.13.1.tgz",
+      "integrity": "sha512-81PIMmVLnCNLO/fFOQxdQkvEq/+Hfpv24XNJfpyZhTRfO0QcmQIF/PgCa1zCOj2w1hrn12MFLyaJ/G0+Mxtfag==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
         "prop-types": "^15.6.2",
-        "scheduler": "^0.19.0"
+        "scheduler": "^0.19.1"
       }
     },
     "react-error-overlay": {
@@ -11504,6 +11537,18 @@
           "requires": {
             "esutils": "^2.0.2",
             "isarray": "^1.0.0"
+          }
+        },
+        "eslint-loader": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/eslint-loader/-/eslint-loader-3.0.3.tgz",
+          "integrity": "sha512-+YRqB95PnNvxNp1HEjQmvf9KNvCin5HXYYseOXVC2U0KEcw4IkQ2IQEBG46j7+gW39bMzeu0GsUhVbBY3Votpw==",
+          "requires": {
+            "fs-extra": "^8.1.0",
+            "loader-fs-cache": "^1.0.2",
+            "loader-utils": "^1.2.3",
+            "object-hash": "^2.0.1",
+            "schema-utils": "^2.6.1"
           }
         },
         "eslint-plugin-import": {
@@ -12202,9 +12247,9 @@
       }
     },
     "scheduler": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.0.tgz",
-      "integrity": "sha512-xowbVaTPe9r7y7RUejcK73/j8tt2jfiyTednOvHbA8JoClvMYCp+r8QegLwK/n8zWQAtZb1fFnER4XLBZXrCxA==",
+      "version": "0.19.1",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.19.1.tgz",
+      "integrity": "sha512-n/zwRWRYSUj0/3g/otKDRPMh6qv2SYMWNq85IEa8iZyAv8od9zDYpGSnpBEjNgcMNq6Scbu5KfIPxNF72R/2EA==",
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -13107,13 +13152,13 @@
       }
     },
     "styled-components": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.0.1.tgz",
-      "integrity": "sha512-E0xKTRIjTs4DyvC1MHu/EcCXIj6+ENCP8hP01koyoADF++WdBUOrSGwU1scJRw7/YaYOhDvvoad6VlMG+0j53A==",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.1.0.tgz",
+      "integrity": "sha512-0Qs2wEkFBXHFlysz6CV831VG6HedcrFUwChjnWylNivsx14MtmqQsohi21rMHZxzuTba063dEyoe/SR6VGJI7Q==",
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
-        "@emotion/is-prop-valid": "^0.8.3",
+        "@emotion/is-prop-valid": "^0.8.8",
         "@emotion/stylis": "^0.8.4",
         "@emotion/unitless": "^0.7.4",
         "babel-plugin-styled-components": ">= 1",
@@ -15724,6 +15769,15 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
       "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw=="
+    },
+    "xregexp": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.3.0.tgz",
+      "integrity": "sha512-7jXDIFXh5yJ/orPn4SXjuVrWWoi4Cr8jfV1eHv9CixKSbU+jY4mxfrBwAuDvupPNKpMUY+FeIqsVw/JLT9+B8g==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime-corejs3": "^7.8.3"
+      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
       "prop-types": "^15.7.2",
       "react": "^16.13.0",
       "react-dom": "^16.13.0",
+      "react-icons": "^3.10.0",
       "react-router-dom": "^5.1.2",
       "react-scripts": "3.4.0",
       "styled-components": "^5.0.1"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,6 +5,7 @@
    "dependencies": {
       "lodash": "^4.17.15",
       "moment": "^2.24.0",
+      "ordinal": "^1.0.3",
       "polished": "^3.5.2",
       "prop-types": "^15.7.2",
       "react": "^16.13.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,14 +5,14 @@
    "dependencies": {
       "lodash": "^4.17.15",
       "moment": "^2.24.0",
-      "polished": "^3.5.1",
+      "polished": "^3.5.2",
       "prop-types": "^15.7.2",
-      "react": "^16.13.0",
-      "react-dom": "^16.13.0",
+      "react": "^16.13.1",
+      "react-dom": "^16.13.1",
       "react-icons": "^3.10.0",
       "react-router-dom": "^5.1.2",
       "react-scripts": "3.4.0",
-      "styled-components": "^5.0.1"
+      "styled-components": "^5.1.0"
    },
    "scripts": {
       "start": "react-scripts start",
@@ -37,14 +37,14 @@
    },
    "devDependencies": {
       "eslint": "^6.8.0",
-      "eslint-config-airbnb": "^18.0.1",
-      "eslint-config-prettier": "^6.10.0",
-      "eslint-loader": "^3.0.3",
-      "eslint-plugin-import": "^2.20.1",
+      "eslint-config-airbnb": "^18.1.0",
+      "eslint-config-prettier": "^6.11.0",
+      "eslint-loader": "^3.0.4",
+      "eslint-plugin-import": "^2.20.2",
       "eslint-plugin-jsx-a11y": "^6.2.3",
-      "eslint-plugin-prettier": "^3.1.2",
-      "eslint-plugin-react": "^7.18.3",
-      "lint-staged": "^10.0.8",
+      "eslint-plugin-prettier": "^3.1.3",
+      "eslint-plugin-react": "^7.19.0",
+      "lint-staged": "^10.1.7",
       "prettier": "^1.19.1"
    },
    "lint-staged": {

--- a/frontend/src/components/CalendarList/CalendarListItem/CalendarListItem.js
+++ b/frontend/src/components/CalendarList/CalendarListItem/CalendarListItem.js
@@ -1,18 +1,24 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import JsonParser from '../../../services/parsing/JsonParser';
+import RoomData from '../../RoomData/RoomData';
 import { StyledCalendarListItem, CalendarHeader, CalendarLink, CalendarDescription } from './CalendarListItem_styles';
 
 const CalendarListItem = ( { calendarData } ) => {
-   const { description, summary,id } = calendarData;
+   const { description, summary, id } = calendarData;
+   const defaultRoomData = {
+      name: summary,
+      description,
+   };
+   const room = JsonParser.parse( description, defaultRoomData );
 
    return (
       <StyledCalendarListItem>
          <CalendarLink to={ `/room/${id.split( '@' )[0]}` }>
 
-            <CalendarHeader >{ summary }</CalendarHeader>
+            <CalendarHeader>{ room.name }</CalendarHeader>
             <CalendarDescription >
-               { description || 'No description.' }
-               { /* there should be more info in the future: todo in caendars first */ }
+               <RoomData room={ room } />
             </CalendarDescription>
          </CalendarLink>
       </StyledCalendarListItem>

--- a/frontend/src/components/CalendarList/CalendarListItem/CalendarListItem.js
+++ b/frontend/src/components/CalendarList/CalendarListItem/CalendarListItem.js
@@ -1,16 +1,12 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import JsonParser from '../../../services/parsing/JsonParser';
+import RoomMetadataDTO from '../../../services/parsing/RoomMetadataDTO';
 import RoomData from '../../RoomData/RoomData';
 import { StyledCalendarListItem, CalendarHeader, CalendarLink, CalendarDescription } from './CalendarListItem_styles';
 
 const CalendarListItem = ( { calendarData } ) => {
    const { description, summary, id } = calendarData;
-   const defaultRoomData = {
-      name: summary,
-      description,
-   };
-   const room = JsonParser.parse( description, defaultRoomData );
+   const room = RoomMetadataDTO.from( summary, description );
 
    return (
       <StyledCalendarListItem>
@@ -32,6 +28,5 @@ CalendarListItem.propTypes = {
       description: PropTypes.string,
    } ).isRequired,
 };
-
 
 export default CalendarListItem;

--- a/frontend/src/components/RoomData/RoomData.js
+++ b/frontend/src/components/RoomData/RoomData.js
@@ -1,16 +1,27 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { StyledRoomData, RoomTitle, RoomDescription } from './RoomData_styles';
+import { FaChalkboard, FaChair } from 'react-icons/fa';
+import { GiFilmProjector } from 'react-icons/gi';
+import JsonParser from '../../services/parsing/JsonParser';
+import { StyledRoomData, RoomTitle, RoomDescription, RoomLocation, RoomIndicators, Indicator } from './RoomData_styles';
 
-const RoomData = ( { roomData: { summary, description } } ) => {
+const RoomData = ( { roomData } ) => {
+   const defaultRoomData = {
+      name: roomData.summary,
+      description: roomData.description
+   };
+   const room = JsonParser.parse( roomData.description, defaultRoomData );
+
    return (
       <StyledRoomData>
-         <RoomTitle>
-            { summary }
-         </RoomTitle>
-         <RoomDescription>
-            { description }
-         </RoomDescription>
+         <RoomTitle>{ room.name }</RoomTitle>
+         { room.description ? <RoomDescription>{ room.description }</RoomDescription> : '' }
+         { room.location ? <RoomLocation>{ room.location.building }, { room.location.floorNo } floor</RoomLocation> : '' }
+         <RoomIndicators>
+            <Indicator>{ room.hasWhiteboard ? <FaChalkboard /> : '' }</Indicator>
+            <Indicator>{ room.hasProjector ? <GiFilmProjector /> : '' }</Indicator>
+            <Indicator>{ room.seatsNo ? <><FaChair /> { room.seatsNo }</> : '' }</Indicator>
+         </RoomIndicators>
       </StyledRoomData>
    );
 };
@@ -21,6 +32,5 @@ RoomData.propTypes = {
       description: PropTypes.string.isRequired,
    } ).isRequired,
 };
-
 
 export default RoomData;

--- a/frontend/src/components/RoomData/RoomData.js
+++ b/frontend/src/components/RoomData/RoomData.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import ordinal from 'ordinal';
 import { FaChalkboard, FaChair } from 'react-icons/fa';
 import { GiFilmProjector } from 'react-icons/gi';
+import RoomMetadataDTO from '../../services/parsing/RoomMetadataDTO';
 import { StyledRoomData, RoomDescription, RoomLocation, RoomIndicators, Indicator } from './RoomData_styles';
 
 const RoomData = ( { room } ) => {
@@ -22,7 +23,7 @@ const RoomData = ( { room } ) => {
 };
 
 RoomData.propTypes = {
-   room: PropTypes.shape().isRequired,
+   room: PropTypes.instanceOf( RoomMetadataDTO ).isRequired,
 };
 
 export default RoomData;

--- a/frontend/src/components/RoomData/RoomData.js
+++ b/frontend/src/components/RoomData/RoomData.js
@@ -14,9 +14,9 @@ const RoomData = ( { room } ) => {
          <RoomDescription>{ description }</RoomDescription>
          <RoomLocation>{ location ? <>{ location.building }, { ordinal( location.floorNo ) } floor</> : '' }</RoomLocation>
          <RoomIndicators>
-            <Indicator active={ hasWhiteboard }><FaChalkboard /></Indicator>
-            <Indicator active={ hasProjector }><GiFilmProjector /></Indicator>
-            <Indicator active={ seatsNo }><FaChair /> { room.seatsNo }</Indicator>
+            <Indicator active={ hasWhiteboard }><abbr title="Whiteboard"><FaChalkboard /></abbr></Indicator>
+            <Indicator active={ hasProjector }><abbr title="Projector"><GiFilmProjector /></abbr></Indicator>
+            <Indicator active={ seatsNo }><abbr title="Seats"><FaChair /></abbr> { room.seatsNo }</Indicator>
          </RoomIndicators>
       </StyledRoomData>
    );

--- a/frontend/src/components/RoomData/RoomData.js
+++ b/frontend/src/components/RoomData/RoomData.js
@@ -3,20 +3,13 @@ import PropTypes from 'prop-types';
 import ordinal from 'ordinal';
 import { FaChalkboard, FaChair } from 'react-icons/fa';
 import { GiFilmProjector } from 'react-icons/gi';
-import JsonParser from '../../services/parsing/JsonParser';
-import { StyledRoomData, RoomTitle, RoomDescription, RoomLocation, RoomIndicators, Indicator } from './RoomData_styles';
+import { StyledRoomData, RoomDescription, RoomLocation, RoomIndicators, Indicator } from './RoomData_styles';
 
-const RoomData = ( { roomData } ) => {
-   const defaultRoomData = {
-      name: roomData.summary,
-      description: roomData.description
-   };
-   const room = JsonParser.parse( roomData.description, defaultRoomData );
-   const { name, description, location, hasProjector, hasWhiteboard, seatsNo } = room;
+const RoomData = ( { room } ) => {
+   const { description, location, hasProjector, hasWhiteboard, seatsNo } = room;
 
    return (
       <StyledRoomData>
-         <RoomTitle>{ name }</RoomTitle>
          <RoomDescription>{ description }</RoomDescription>
          <RoomLocation>{ location ? <>{ location.building }, { ordinal( location.floorNo ) } floor</> : '' }</RoomLocation>
          <RoomIndicators>
@@ -29,10 +22,7 @@ const RoomData = ( { roomData } ) => {
 };
 
 RoomData.propTypes = {
-   roomData: PropTypes.shape( {
-      summary: PropTypes.string.isRequired,
-      description: PropTypes.string.isRequired,
-   } ).isRequired,
+   room: PropTypes.shape().isRequired,
 };
 
 export default RoomData;

--- a/frontend/src/components/RoomData/RoomData.js
+++ b/frontend/src/components/RoomData/RoomData.js
@@ -11,16 +11,17 @@ const RoomData = ( { roomData } ) => {
       description: roomData.description
    };
    const room = JsonParser.parse( roomData.description, defaultRoomData );
+   const { name, description, location, hasProjector, hasWhiteboard, seatsNo } = room;
 
    return (
       <StyledRoomData>
-         <RoomTitle>{ room.name }</RoomTitle>
-         { room.description ? <RoomDescription>{ room.description }</RoomDescription> : '' }
-         { room.location ? <RoomLocation>{ room.location.building }, { room.location.floorNo } floor</RoomLocation> : '' }
+         <RoomTitle>{ name }</RoomTitle>
+         <RoomDescription>{ description }</RoomDescription>
+         <RoomLocation>{ location ? <>{ location.building }, { location.floorNo } floor</> : '' }</RoomLocation>
          <RoomIndicators>
-            <Indicator>{ room.hasWhiteboard ? <FaChalkboard /> : '' }</Indicator>
-            <Indicator>{ room.hasProjector ? <GiFilmProjector /> : '' }</Indicator>
-            <Indicator>{ room.seatsNo ? <><FaChair /> { room.seatsNo }</> : '' }</Indicator>
+            <Indicator active={ hasWhiteboard }><FaChalkboard /></Indicator>
+            <Indicator active={ hasProjector }><GiFilmProjector /></Indicator>
+            <Indicator active={ seatsNo }><FaChair /> { room.seatsNo }</Indicator>
          </RoomIndicators>
       </StyledRoomData>
    );

--- a/frontend/src/components/RoomData/RoomData.js
+++ b/frontend/src/components/RoomData/RoomData.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import ordinal from 'ordinal';
 import { FaChalkboard, FaChair } from 'react-icons/fa';
 import { GiFilmProjector } from 'react-icons/gi';
 import JsonParser from '../../services/parsing/JsonParser';
@@ -17,7 +18,7 @@ const RoomData = ( { roomData } ) => {
       <StyledRoomData>
          <RoomTitle>{ name }</RoomTitle>
          <RoomDescription>{ description }</RoomDescription>
-         <RoomLocation>{ location ? <>{ location.building }, { location.floorNo } floor</> : '' }</RoomLocation>
+         <RoomLocation>{ location ? <>{ location.building }, { ordinal( location.floorNo ) } floor</> : '' }</RoomLocation>
          <RoomIndicators>
             <Indicator active={ hasWhiteboard }><FaChalkboard /></Indicator>
             <Indicator active={ hasProjector }><GiFilmProjector /></Indicator>

--- a/frontend/src/components/RoomData/RoomData_styles.js
+++ b/frontend/src/components/RoomData/RoomData_styles.js
@@ -1,15 +1,7 @@
 import styled from 'styled-components/macro';
 
 export const StyledRoomData = styled.div`
-  max-width: 400px;
-  margin: 20px auto ;
   text-align: center;
-
-`;
-
-export const RoomTitle = styled.h2`
-   font-size: ${( { theme } )=>theme.font.size.l};
-   margin: 10px;
 `;
 
 export const RoomDescription = styled.div`

--- a/frontend/src/components/RoomData/RoomData_styles.js
+++ b/frontend/src/components/RoomData/RoomData_styles.js
@@ -29,4 +29,12 @@ export const RoomIndicators = styled.div`
 
 export const Indicator = styled.div`
   margin: 0 10px;
+
+  display: flex;
+  align-items: center;
+
+  svg {
+    margin: 0 5px;
+    color: ${( { active, theme } ) => active ? theme.primary : 'gray'};
+  }
 `;

--- a/frontend/src/components/RoomData/RoomData_styles.js
+++ b/frontend/src/components/RoomData/RoomData_styles.js
@@ -13,5 +13,20 @@ export const RoomTitle = styled.h2`
 `;
 
 export const RoomDescription = styled.div`
+  margin: 10px;
 `;
 
+export const RoomLocation = styled.div`
+  font-style: italic;
+  margin: 10px;
+`;
+
+export const RoomIndicators = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+`;
+
+export const Indicator = styled.div`
+  margin: 0 10px;
+`;

--- a/frontend/src/components/RoomData/RoomData_styles.js
+++ b/frontend/src/components/RoomData/RoomData_styles.js
@@ -25,6 +25,10 @@ export const Indicator = styled.div`
   display: flex;
   align-items: center;
 
+  abbr {
+    display: flex;
+  }
+
   svg {
     margin: 0 5px;
     color: ${( { active, theme } ) => active ? theme.primary : 'gray'};

--- a/frontend/src/components/RoomHeader/RoomHeader.js
+++ b/frontend/src/components/RoomHeader/RoomHeader.js
@@ -1,15 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import JsonParser from '../../services/parsing/JsonParser';
+import RoomMetadataDTO from '../../services/parsing/RoomMetadataDTO';
 import { StyledRoomHeader, RoomTitle } from './RoomHeader_styles';
 import RoomData from '../RoomData/RoomData';
 
 const RoomHeader = ( { roomData } ) => {
-   const defaultRoomData = {
-      name: roomData.summary,
-      description: roomData.description
-   };
-   const room = JsonParser.parse( roomData.description, defaultRoomData );
+   const room = RoomMetadataDTO.from( roomData.summary, roomData.description );
 
    return (
       <StyledRoomHeader>
@@ -20,7 +16,10 @@ const RoomHeader = ( { roomData } ) => {
 };
 
 RoomHeader.propTypes = {
-   roomData: PropTypes.string.isRequired,
+   roomData: PropTypes.shape( {
+      summary: PropTypes.string.isRequired,
+      description: PropTypes.string.isRequired,
+   } ).isRequired,
 };
 
 export default RoomHeader;

--- a/frontend/src/components/RoomHeader/RoomHeader.js
+++ b/frontend/src/components/RoomHeader/RoomHeader.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import JsonParser from '../../services/parsing/JsonParser';
+import { StyledRoomHeader, RoomTitle } from './RoomHeader_styles';
+import RoomData from '../RoomData/RoomData';
+
+const RoomHeader = ( { roomData } ) => {
+   const defaultRoomData = {
+      name: roomData.summary,
+      description: roomData.description
+   };
+   const room = JsonParser.parse( roomData.description, defaultRoomData );
+
+   return (
+      <StyledRoomHeader>
+         <RoomTitle>{ room.name }</RoomTitle>
+         <RoomData room={ room } />
+      </StyledRoomHeader>
+   );
+};
+
+RoomHeader.propTypes = {
+   roomData: PropTypes.string.isRequired,
+};
+
+export default RoomHeader;

--- a/frontend/src/components/RoomHeader/RoomHeader_styles.js
+++ b/frontend/src/components/RoomHeader/RoomHeader_styles.js
@@ -1,0 +1,12 @@
+import styled from 'styled-components/macro';
+
+export const StyledRoomHeader = styled.div`
+  max-width: 400px;
+  margin: 20px auto ;
+  text-align: center;
+`;
+
+export const RoomTitle = styled.h2`
+   font-size: ${( { theme } )=>theme.font.size.l};
+   margin: 10px;
+`;

--- a/frontend/src/pages/Room/Room.js
+++ b/frontend/src/pages/Room/Room.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useContext, useReducer } from 'react';
 import moment from 'moment';
 import { useParams } from 'react-router-dom';
 import EventList from '../../components/EventList/EventList';
-import RoomData from '../../components/RoomData/RoomData';
+import RoomHeader from '../../components/RoomHeader/RoomHeader';
 import FetchContext from '../../services/fetching/FetchContext';
 import ToggleSwitch from '../../components/ToggleSwitch/ToggleSwitch';
 
@@ -39,7 +39,7 @@ const Room = () => {
             </h1>
          ) : (
             <>
-               <RoomData roomData={ calendar.calendar } />
+               <RoomHeader roomData={ calendar.calendar } />
                <ToggleSwitch
                   toggleFunc={ toggleIsCompact }
                   value={ isCompact }

--- a/frontend/src/services/parsing/JsonParser.js
+++ b/frontend/src/services/parsing/JsonParser.js
@@ -1,0 +1,16 @@
+const JsonParser = {
+   parse: ( text, fallback ) => {
+      let result;
+
+      try {
+         result = JSON.parse( text );
+      }
+      catch ( e ) {
+         result = fallback;
+      }
+
+      return result;
+   }
+};
+
+export default JsonParser;

--- a/frontend/src/services/parsing/RoomMetadataDTO.js
+++ b/frontend/src/services/parsing/RoomMetadataDTO.js
@@ -3,8 +3,8 @@ import JsonParser from './JsonParser';
 class RoomMetadataDTO {
    static from( summary, description ) {
       const fallback = {
-         a: summary,
-         b: description,
+         nm: summary,
+         dc: description,
       };
       const room = JsonParser.parse( description, fallback );
 
@@ -13,8 +13,8 @@ class RoomMetadataDTO {
 
    static fromPlainStrings( name, description ) {
       const fallback = {
-         a: name,
-         b: description,
+         nm: name,
+         dc: description,
       };
 
       return this.fromJSON( fallback );
@@ -23,16 +23,16 @@ class RoomMetadataDTO {
    static fromJSON( room ) {
       const ret = new RoomMetadataDTO();
 
-      ret.name = room.a;
-      ret.description = room.b;
-      ret.seatsNo = room.c;
-      ret.hasProjector = room.d;
-      ret.hasWhiteboard = room.e;
+      ret.name = room.nm;
+      ret.description = room.dc;
+      ret.seatsNo = room.st;
+      ret.hasProjector = room.pj === 1;
+      ret.hasWhiteboard = room.wb === 1;
 
-      if ( room.f ) {
+      if ( room.lc ) {
          ret.location = {
-            building: room.f.a,
-            floorNo: room.f.b,
+            building: room.lc.b,
+            floorNo: room.lc.f,
          };
       }
 

--- a/frontend/src/services/parsing/RoomMetadataDTO.js
+++ b/frontend/src/services/parsing/RoomMetadataDTO.js
@@ -1,0 +1,43 @@
+import JsonParser from './JsonParser';
+
+class RoomMetadataDTO {
+   static from( summary, description ) {
+      const fallback = {
+         a: summary,
+         b: description,
+      };
+      const room = JsonParser.parse( description, fallback );
+
+      return this.fromJSON( room );
+   }
+
+   static fromPlainStrings( name, description ) {
+      const fallback = {
+         a: name,
+         b: description,
+      };
+
+      return this.fromJSON( fallback );
+   }
+
+   static fromJSON( room ) {
+      const ret = new RoomMetadataDTO();
+
+      ret.name = room.a;
+      ret.description = room.b;
+      ret.seatsNo = room.c;
+      ret.hasProjector = room.d;
+      ret.hasWhiteboard = room.e;
+
+      if ( room.f ) {
+         ret.location = {
+            building: room.f.a,
+            floorNo: room.f.b,
+         };
+      }
+
+      return ret;
+   }
+}
+
+export default RoomMetadataDTO;


### PR DESCRIPTION
It turns out that Google Calendar calendar descriptions can be no more than 200 characters long, so we store the data in an uglified format. Example data (stored in calendar's description):

```json
{"a":"Room 1","b":"A small room","f":{"a":"Large building","b":3},"c":10,"d":false,"e":true}
```

The result:

![Screenshot from 2020-04-24 02-39-29](https://user-images.githubusercontent.com/8074163/80162909-e1700f80-85d4-11ea-96e9-3da1a3a40cdd.png)


