### PR TITLE
Room filtering

### DIFF
--- a/frontend/.eslintrc
+++ b/frontend/.eslintrc
@@ -29,6 +29,7 @@
    },
    "rules": {
       "jsx-a11y/href-no-hash": [ "off" ],
+      "jsx-a11y/label-has-associated-control": [ "off" ],
       "react/jsx-filename-extension": 0,
       "import/prefer-default-export": 0,
 

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -4,7 +4,7 @@
 <head>
    <meta charset="utf-8" />
    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
-   <meta name="viewport" content="width=device-width, initial-scale=1" />
+   <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
    <meta name="theme-color" content="#000000" />
    <meta name="description" content="Web site created using create-react-app" />
    <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
@@ -22,7 +22,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600,800&display=swap" rel="stylesheet">
+   <link href="https://fonts.googleapis.com/css?family=Open+Sans:400,600,800&display=swap" rel="stylesheet">
 
    <title>Check Room</title>
 </head>

--- a/frontend/src/components/InputField/InputField.js
+++ b/frontend/src/components/InputField/InputField.js
@@ -1,0 +1,68 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { StyledInputField, Label } from './InputField_styles';
+
+const InputField = ( { label, type, labelPosition, value, onChange } ) => {
+   // The trick below is used to confuse Chrome and Safari's
+   // autocompletion engines. It inserts zero-width spaces between
+   // the letters. This prevents e.g. Safari suggesting user's full
+   // name into field called "Room name".
+   const text = label.split( '' ).join( String.fromCharCode( 8204 ) );
+
+   return (
+      <StyledInputField labelPosition={ labelPosition }>
+         { type === 'text' || type === 'search' ?
+            <Label>
+               { labelPosition === 'left' ? text : null }
+               <input type={ type }
+                  value={ value }
+                  autocompletion="off"
+                  onChange={ ( e ) => onChange( e.target.value ) } />
+               { labelPosition === 'right' ? text : null }
+            </Label>
+            : null }
+
+         { type === 'number' ?
+            <Label>
+               { labelPosition === 'left' ? text : null }
+               <input type="number"
+                  inputtype="numeric"
+                  pattern="[0-9]*"
+                  value={ value }
+                  autocompletion="off"
+                  onChange={ ( e ) => onChange( e.target.value ) } />
+               { labelPosition === 'right' ? text : null }
+            </Label>
+            : null }
+
+         { type === 'checkbox' ?
+            <Label hasCheckbox>
+               { labelPosition === 'left' ? text : null }
+               <input type="checkbox"
+                  checked={ value }
+                  onChange={ ( e ) => onChange( e.target.checked ) } />
+               { labelPosition === 'right' ? text : null }
+            </Label>
+            : null }
+      </StyledInputField>
+   );
+};
+
+InputField.propTypes = {
+   type: PropTypes.string.isRequired,
+   label: PropTypes.string.isRequired,
+   labelPosition: PropTypes.string,
+   value: PropTypes.oneOfType( [
+      PropTypes.string,
+      PropTypes.number,
+      PropTypes.bool,
+   ] ),
+   onChange: PropTypes.func.isRequired,
+};
+
+InputField.defaultProps = {
+   labelPosition: 'left',
+   value: '',
+};
+
+export default InputField;

--- a/frontend/src/components/InputField/InputField_styles.js
+++ b/frontend/src/components/InputField/InputField_styles.js
@@ -1,0 +1,28 @@
+import styled from 'styled-components/macro';
+
+export const StyledInputField = styled.div`
+   input {
+      ${( { labelPosition } ) => {
+      if ( labelPosition === 'left' ) {
+         return 'margin-left: 15px;';
+      }
+
+      return 'margin-right: 15px;';
+   }}
+      width: 200px;
+      max-width: 50vw;
+      padding: 10px;
+      border: solid 1px #b1b1b1;
+      border-radius: 5px;
+   }
+
+   input[type="checkbox"] {
+      width: initial;
+   }
+`;
+
+export const Label = styled.label`
+   display: flex;
+   align-items: center;
+   justify-content: ${( { hasCheckbox } ) => hasCheckbox ? 'center' : 'space-between'};
+`;

--- a/frontend/src/components/RoomList/RoomFilterOptions/RoomFilterOptions.js
+++ b/frontend/src/components/RoomList/RoomFilterOptions/RoomFilterOptions.js
@@ -1,49 +1,47 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { StyledRoomFilterOptions, Field } from './RoomFilterOptions_styles';
+import InputField from '../../InputField/InputField';
+import { StyledRoomFilterOptions } from './RoomFilterOptions_styles';
 
 const RoomFilterOptions = ( { state } ) => {
    const [ filters, setFilters ] = state;
 
    return (
       <StyledRoomFilterOptions>
-         <Field>
-            Name
-            <input type="search"
-               value={ filters.name ?? '' }
-               onChange={ ( e ) => setFilters(
-                  { ...filters, name: e.target.value }
-               ) } />
-         </Field>
+         <InputField
+            label="Name"
+            type="search"
+            value={ filters.name }
+            onChange={ ( val ) => setFilters(
+               { ...filters, name: val }
+            ) } />
 
-         <Field>
-            Seats
-            <input type="number"
-               inputtype="numeric"
-               pattern="[0-9]*"
-               value={ filters.seatsNo ?? '' }
-               onChange={ ( e ) => setFilters(
-                  { ...filters, seatsNo: e.target.value }
-               ) } />
-         </Field>
+         <InputField
+            label="Seats"
+            labelPosition="left"
+            type="number"
+            value={ filters.seatsNo }
+            onChange={ ( val ) => setFilters(
+               { ...filters, seatsNo: val }
+            ) } />
 
-         <Field>
-            <input type="checkbox"
-               checked={ filters.hasProjector ?? false }
-               onChange={ ( e ) => setFilters(
-                  { ...filters, hasProjector: e.target.checked }
-               ) } />
-            Projector
-         </Field>
+         <InputField
+            label="Projector"
+            labelPosition="right"
+            type="checkbox"
+            value={ filters.hasProjector }
+            onChange={ ( val ) => setFilters(
+               { ...filters, hasProjector: val }
+            ) } />
 
-         <Field>
-            <input type="checkbox"
-               checked={ filters.hasWhiteboard ?? false }
-               onChange={ ( e ) => setFilters(
-                  { ...filters, hasWhiteboard: e.target.checked }
-               ) } />
-            Whiteboard
-         </Field>
+         <InputField
+            label="Whiteboard"
+            labelPosition="right"
+            type="checkbox"
+            value={ filters.hasWhiteboard }
+            onChange={ ( val ) => setFilters(
+               { ...filters, hasWhiteboard: val }
+            ) } />
       </StyledRoomFilterOptions>
    );
 };

--- a/frontend/src/components/RoomList/RoomFilterOptions/RoomFilterOptions.js
+++ b/frontend/src/components/RoomList/RoomFilterOptions/RoomFilterOptions.js
@@ -1,0 +1,55 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { StyledRoomFilterOptions, Field } from './RoomFilterOptions_styles';
+
+const RoomFilterOptions = ( { state } ) => {
+   const [ filters, setFilters ] = state;
+
+   return (
+      <StyledRoomFilterOptions>
+         <Field>
+            Name
+            <input type="text"
+               value={ filters.name ?? '' }
+               onChange={ ( e ) => setFilters(
+                  { ...filters, name: e.target.value }
+               ) } />
+         </Field>
+
+         <Field>
+            Seats
+            <input type="number"
+               inputtype="numeric"
+               pattern="[0-9]*"
+               value={ filters.seatsNo ?? '' }
+               onChange={ ( e ) => setFilters(
+                  { ...filters, seatsNo: e.target.value }
+               ) } />
+         </Field>
+
+         <Field>
+            <input type="checkbox"
+               checked={ filters.hasProjector ?? false }
+               onChange={ ( e ) => setFilters(
+                  { ...filters, hasProjector: e.target.checked }
+               ) } />
+            Projector
+         </Field>
+
+         <Field>
+            <input type="checkbox"
+               checked={ filters.hasWhiteboard ?? false }
+               onChange={ ( e ) => setFilters(
+                  { ...filters, hasWhiteboard: e.target.checked }
+               ) } />
+            Whiteboard
+         </Field>
+      </StyledRoomFilterOptions>
+   );
+};
+
+RoomFilterOptions.propTypes = {
+   state: PropTypes.arrayOf( PropTypes.any ).isRequired
+};
+
+export default RoomFilterOptions;

--- a/frontend/src/components/RoomList/RoomFilterOptions/RoomFilterOptions.js
+++ b/frontend/src/components/RoomList/RoomFilterOptions/RoomFilterOptions.js
@@ -9,7 +9,7 @@ const RoomFilterOptions = ( { state } ) => {
       <StyledRoomFilterOptions>
          <Field>
             Name
-            <input type="text"
+            <input type="search"
                value={ filters.name ?? '' }
                onChange={ ( e ) => setFilters(
                   { ...filters, name: e.target.value }

--- a/frontend/src/components/RoomList/RoomFilterOptions/RoomFilterOptions_styles.js
+++ b/frontend/src/components/RoomList/RoomFilterOptions/RoomFilterOptions_styles.js
@@ -12,21 +12,10 @@ export const StyledRoomFilterOptions = styled.div`
    display: grid;
    grid-gap: 10px;
 
-   ${( { theme } ) => theme.mdq.md} {
+   ${( { theme } ) => theme.mdq.sm} {
       grid-template-columns: 1fr 1fr;
-   }
-`;
-
-export const Field = styled.label`
-   text-align: center;
-
-   input[type="search"],
-   input[type="number"] {
-      width: 200px;
-      margin-left: 15px;
-
-      padding: 10px;
-      border: solid 1px #b1b1b1;
-      border-radius: 5px;
+      label {
+         justify-content: center;
+      }
    }
 `;

--- a/frontend/src/components/RoomList/RoomFilterOptions/RoomFilterOptions_styles.js
+++ b/frontend/src/components/RoomList/RoomFilterOptions/RoomFilterOptions_styles.js
@@ -1,0 +1,20 @@
+import styled from 'styled-components/macro';
+
+export const StyledRoomFilterOptions = styled.div`
+   width: 100%;
+   max-width: 600px;
+
+   display: grid;
+   grid-template-columns: 1fr 1fr;
+   grid-gap: 10px;
+`;
+
+export const Field = styled.label`
+   text-align: center;
+
+   input[type="text"],
+   input[type="number"] {
+      width: 200px;
+      margin-left: 15px;
+   }
+`;

--- a/frontend/src/components/RoomList/RoomFilterOptions/RoomFilterOptions_styles.js
+++ b/frontend/src/components/RoomList/RoomFilterOptions/RoomFilterOptions_styles.js
@@ -1,20 +1,32 @@
 import styled from 'styled-components/macro';
+import { darken } from 'polished';
 
 export const StyledRoomFilterOptions = styled.div`
    width: 100%;
    max-width: 600px;
 
+   border: 2px solid ${( { theme } ) => darken( 0.1, theme.primary )};
+   border-radius: 20px;
+   padding: 20px;
+
    display: grid;
-   grid-template-columns: 1fr 1fr;
    grid-gap: 10px;
+
+   ${( { theme } ) => theme.mdq.md} {
+      grid-template-columns: 1fr 1fr;
+   }
 `;
 
 export const Field = styled.label`
    text-align: center;
 
-   input[type="text"],
+   input[type="search"],
    input[type="number"] {
       width: 200px;
       margin-left: 15px;
+
+      padding: 10px;
+      border: solid 1px #b1b1b1;
+      border-radius: 5px;
    }
 `;

--- a/frontend/src/components/RoomList/RoomList.js
+++ b/frontend/src/components/RoomList/RoomList.js
@@ -1,19 +1,38 @@
-import React from 'react';
+import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import RoomListItem from './RoomListItem/RoomListItem';
-import { StyledRoomList } from './RoomList_styles';
+import RoomFilterOptions from './RoomFilterOptions/RoomFilterOptions';
+import RoomMetadataDTO from '../../services/parsing/RoomMetadataDTO';
+import { StyledRoomList, FilteredRoomList } from './RoomList_styles';
 
 const RoomList = ( { roomsData } ) => {
 
-   const rooms = roomsData.map( ( ( room )=> (
-      <RoomListItem key={ room.id } roomData={ room } />
-   ) ) );
+   const [ filters, setFilters ] = useState( {} );
+
+   const rooms = useMemo( () => {
+      return roomsData
+         .map( ( room ) => ( { room, metadata: RoomMetadataDTO.from( room.summary, room.description ) } ) )
+         .filter( ( { metadata } ) => filters.hasProjector ?
+            metadata.hasProjector : true )
+         .filter( ( { metadata } ) => filters.hasWhiteboard ?
+            metadata.hasWhiteboard : true )
+         .filter( ( { metadata } ) => filters.seatsNo ?
+            metadata.seatsNo >= filters.seatsNo : true )
+         .filter( ( { metadata } ) => filters.name ?
+            metadata.name.toLowerCase().includes( filters.name.toLowerCase() ) : true )
+         .map( ( ( { room } ) => (
+            <RoomListItem key={ room.id } roomData={ room } />
+         ) ) );
+   }, [ filters, roomsData ] );
 
    return (
       <StyledRoomList>
-         { rooms.length < 1 ? <h1>No Calendars</h1> : (
-            rooms
-         ) }
+         <RoomFilterOptions state={ [ filters, setFilters ] } />
+         <FilteredRoomList>
+            { rooms.length < 1 ? <h1>No Calendars</h1> : (
+               rooms
+            ) }
+         </FilteredRoomList>
       </StyledRoomList>
    );
 };

--- a/frontend/src/components/RoomList/RoomListItem/RoomListItem.js
+++ b/frontend/src/components/RoomList/RoomListItem/RoomListItem.js
@@ -11,7 +11,6 @@ const RoomListItem = ( { roomData } ) => {
    return (
       <StyledRoomListItem>
          <CalendarLink to={ `/room/${id.split( '@' )[0]}` }>
-
             <CalendarHeader>{ room.name }</CalendarHeader>
             <CalendarDescription >
                <RoomData room={ room } />

--- a/frontend/src/components/RoomList/RoomList_styles.js
+++ b/frontend/src/components/RoomList/RoomList_styles.js
@@ -1,7 +1,14 @@
 import styled from 'styled-components/macro';
 
-export const StyledRoomList = styled.ul`
-  padding: 25px 7% 10px;
+export const StyledRoomList = styled.div`
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export const FilteredRoomList = styled.ul`
+  padding: 5px 7% 10px;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
It adds:
- searching by room name fragment,
- filtering by number of seats required,
- filtering by projector and whiteboard.

I tried to make it work and behave sanely on Chrome, Firefox, and mobile Safari (hence the `user-scalable` change).

Result - large screen:

![Screenshot from 2020-04-26 20-55-27](https://user-images.githubusercontent.com/8074163/80316939-0f399c00-8801-11ea-9fb2-3265d489484a.png)

Result - small screen:

![Screenshot from 2020-04-26 20-52-21](https://user-images.githubusercontent.com/8074163/80316946-1791d700-8801-11ea-8fb5-56cd6244e132.png)
