### PR TITLE
Tweak seeding and fix event adding

### DIFF
--- a/backend/app/calendar/CalendarClient.js
+++ b/backend/app/calendar/CalendarClient.js
@@ -1,4 +1,5 @@
 const Connection = require( './Connection' );
+const { sleep } = require( '../util.js' );
 
 class CalendarClient {
    constructor() {
@@ -46,6 +47,8 @@ class CalendarClient {
       if ( event.end.diff( event.start, 'minutes' ) < 5 ) {
          throw new Error( 'Invalid event length' );
       }
+
+      await sleep( 500 );
 
       const overlapping = await this.calendar.events.list( {
          calendarId,

--- a/backend/app/util.js
+++ b/backend/app/util.js
@@ -1,0 +1,7 @@
+function sleep( ms ) {
+   return new Promise( ( resolve ) => setTimeout( resolve, ms ) );
+}
+
+module.exports = {
+   sleep,
+};

--- a/backend/bin/seed-rooms.js
+++ b/backend/bin/seed-rooms.js
@@ -55,21 +55,24 @@ function randomSummary() {
 async function seedEvents( days, room ) {
    const calendars = room === 'all' ? await allRooms() : [ room ];
 
-   calendars.forEach( ( calendar ) => {
-      for ( let i = 0; i < days; i += 1 ) {
-         const day = moment().startOf( 'day' ).add( i, 'day' );
+   for ( let i = 0; i < calendars.length; i += 1 ) {
+      const calendar = calendars[i];
 
-         for ( let j = 0; j < 3; j += 1 ) {
+      for ( let j = 0; j < days; j += 1 ) {
+         const day = moment().startOf( 'day' ).add( j, 'day' );
+
+         for ( let l = 0; l < 3; l += 1 ) {
             const start = randUniform( 7 * 2, 15 * 2 ) * 30;
             const length = randUniform( 1, 4 ) * 60;
 
             const startDate = moment( day ).add( start, 'minute' );
             const endDate = moment( startDate ).add( length, 'minute' );
 
-            addEvent( calendar, startDate, endDate, randomSummary() );
+            // eslint-disable-next-line no-await-in-loop
+            await addEvent( calendar, startDate, endDate, randomSummary() );
          }
       }
-   } );
+   }
 }
 
 const { argv } = yargs

--- a/backend/bin/seed-rooms.js
+++ b/backend/bin/seed-rooms.js
@@ -60,8 +60,8 @@ async function seedEvents( days, room ) {
          const day = moment().startOf( 'day' ).add( i, 'day' );
 
          for ( let j = 0; j < 3; j += 1 ) {
-            const start = randUniform( 7 * 60, 15 * 60 );
-            const length = randUniform( 5, 4 * 60 );
+            const start = randUniform( 7 * 2, 15 * 2 ) * 30;
+            const length = randUniform( 1, 4 ) * 60;
 
             const startDate = moment( day ).add( start, 'minute' );
             const endDate = moment( startDate ).add( length, 'minute' );
@@ -72,7 +72,7 @@ async function seedEvents( days, room ) {
    } );
 }
 
-const { argv } = require( 'yargs' )
+const { argv } = yargs
    .usage( 'Usage: npm run seed-rooms -- --days [days] --room [calendar|"all"]' )
    .demandOption( [ 'days', 'room' ] );
 


### PR DESCRIPTION
This makes seeding more sane (more demo-friendly), and fixes race condition that caused overlapping events to be added.

Perhaps we could somehow enforce it server-side later on (something similar to a mutex on event adding for each calendar).