### PR TITLE
Fix nginx infinite redirect loop when redirecting to HTTPS

### DIFF
--- a/docker/nginx.template.conf
+++ b/docker/nginx.template.conf
@@ -73,9 +73,20 @@ http {
 
   # Our virtualenv.
   server {
+    # Force HTTPS in production.
     if ($host = checkroom.herokuapp.com) {
-        return 301 https://$host$request_uri;
+      set $redir A;
     }
+
+    if ($scheme = http) {
+      set $redir "${redir}B";
+    }
+
+    if ($redir = AB) {
+      return 301 https://$host$request_uri;
+    }
+
+    # Main configuration.
     listen ${PORT};
 
     location / {


### PR DESCRIPTION
Fix up to #63 .

We shouldn't send 301 if we are already on HTTPS.