### PR TITLE
Fix nginx endless https redirect loop when behind heroku proxy

### DIFF
--- a/docker/nginx.template.conf
+++ b/docker/nginx.template.conf
@@ -74,15 +74,7 @@ http {
   # Our virtualenv.
   server {
     # Force HTTPS in production.
-    if ($host = checkroom.herokuapp.com) {
-      set $redir A;
-    }
-
-    if ($scheme = http) {
-      set $redir "${redir}B";
-    }
-
-    if ($redir = AB) {
+    if ($http_x_forwarded_proto = http) {
       return 301 https://$host$request_uri;
     }
 


### PR DESCRIPTION
Because of Heroku proxy, our backend always receives HTTP requests. If we want to redirect users to HTTPS, we need to look at the X-Forwarded-Proto header.