### PR TITLE
Run eslint on correct directory, using correct version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,14 +19,14 @@ jobs:
     before_install:
     - cd backend
     script:
-    - eslint . --max-warnings=0
+    - npx eslint . --max-warnings=0
     - npm run test
 
   - stage: lint frontend
     before_install:
     - cd frontend
     script:
-    - eslint . --max-warnings=0
+    - npx eslint src --max-warnings=0
 
   - stage: deploy
     if: branch = master


### PR DESCRIPTION
It doesn't actually speed up our Travis, but if we were to build first and test second, ESLint would have been run on the `build` folder (taking forever).

I'm not sure whether `npx` is required, but why not.